### PR TITLE
Fix: min height

### DIFF
--- a/app/js/ellipsis.js
+++ b/app/js/ellipsis.js
@@ -69,6 +69,7 @@ angular.module('sn.ellipsis', [
               return;
             }
 
+            testEl.style.maxHeight = 'none';
             testEl.style.height = 'auto';
             testEl.style.width = elementWidth + 'px';
 


### PR DESCRIPTION
Fix clipText function when element has max-height property set
