### PR TITLE
Improve element comparison; add per-character clipping strategy

### DIFF
--- a/app/js/ellipsis.js
+++ b/app/js/ellipsis.js
@@ -93,8 +93,19 @@ angular.module('sn.ellipsis', [
             }
 
             while (testEl.offsetHeight > elementHeight) {
+              // backup copy of text
+              var _text = text;
+
               text = text.split(' ');
               text = text.splice(0, (text.length-1)).join(' ');
+
+              // if text is now empty, it means a space char wasn't found
+              // (typically in CN or JP strings) - fall back to per-character
+              // trimming strategy
+              if (text === '') {
+                text = _text.slice(0, -1);
+              }
+
               testEl.innerHTML = text + ellipsis;
             }
 

--- a/app/js/ellipsis.js
+++ b/app/js/ellipsis.js
@@ -73,6 +73,12 @@ angular.module('sn.ellipsis', [
             testEl.style.height = 'auto';
             testEl.style.width = elementWidth + 'px';
 
+            // apply computed font/padding/margin styles to ensure test element
+            // is properly comparable with its visible equivalent
+            testEl.style.fontSize = window.getComputedStyle($element[0]).fontSize;
+            testEl.style.padding = window.getComputedStyle($element[0]).padding;
+            testEl.style.margin = window.getComputedStyle($element[0]).margin;
+
             // hide test element
             testEl.style.opacity = 0;
             testEl.style.position = 'absolute';


### PR DESCRIPTION
- Copy font, padding and margin styles to hidden test element, since once it changes CSS scope it may not look the same, making the comparison logic invalid and potentially leading to an unwanted loop of text clipping if the test element's font is larger.
- Add a fallback per-character clipping strategy for use with, for example, Chinese characters where the space character is not used to separate words.
