### PR TITLE
fix(ellipsis): add support for dynamic content

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,1 +1,10 @@
+<h1>Examples</h1>
+
+<h2>Static Content</h2>
 <p snEllipsis>Ullamco esse laborum dolor eiusmod laboris aliquip aute aute aute. Ullamco velit ad laboris consequat. Deserunt ad reprehenderit cupidatat do labore esse. Occaecat nostrud mollit commodo ut ex elit fugiat et reprehenderit quis. Fugiat aliquip excepteur quis sunt sint consectetur duis elit quis ex fugiat quis eiusmod. Ad pariatur ipsum nulla sunt est non ut id et nisi culpa voluptate mollit ad. Tempor cupidatat esse ad in cillum incididunt quis. Nulla cillum qui aute labore quis ad cillum ullamco adipisicing qui est nulla amet. Nisi consectetur sint nostrud est duis dolore enim aliqua esse laboris Lorem.</p>
+
+<h2>Content Binding</h2>
+<p snEllipsis>{{ textContent }}</p>
+
+<h2>inneHTML Binding</h2>
+<p snEllipsis [innerHTML]="htmlContent"></p>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -5,4 +5,35 @@ import { Component } from '@angular/core';
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })
-export class AppComponent { }
+export class AppComponent {
+  textContent = `
+    Ullamco esse laborum dolor eiusmod laboris aliquip \
+    aute aute aute. Ullamco velit ad laboris consequat. \
+    Deserunt ad reprehenderit cupidatat do labore esse. \
+    Occaecat nostrud mollit commodo ut ex elit fugiat et \
+    reprehenderit quis. Fugiat aliquip excepteur quis \
+    sunt sint consectetur duis elit quis ex fugiat quis \
+    eiusmod. Ad pariatur ipsum nulla sunt est non ut id \
+    et nisi culpa voluptate mollit ad. Tempor cupidatat \
+    esse ad in cillum incididunt quis. Nulla cillum qui \
+    aute labore quis ad cillum ullamco adipisicing qui \
+    est nulla amet. Nisi consectetur sint nostrud est \
+    duis dolore enim aliqua esse laboris Lorem.
+  `;
+
+  htmlContent = `
+    Ullamco esse laborum dolor eiusmod laboris aliquip \
+    aute aute aute. Ullamco velit ad laboris consequat. \
+    <br> <br> \
+    Deserunt ad reprehenderit cupidatat do labore esse. \
+    Occaecat nostrud mollit commodo ut ex elit fugiat et \
+    reprehenderit quis. Fugiat aliquip excepteur quis \
+    sunt sint consectetur duis elit quis ex fugiat quis \
+    eiusmod. Ad pariatur ipsum nulla sunt est non ut id \
+    et nisi culpa voluptate mollit ad. Tempor cupidatat \
+    esse ad in cillum incididunt quis. Nulla cillum qui \
+    aute labore quis ad cillum ullamco adipisicing qui \
+    est nulla amet. Nisi consectetur sint nostrud est \
+    duis dolore enim aliqua esse laboris Lorem.
+  `;
+}

--- a/src/app/ellipsis/ellipsis.directive.spec.ts
+++ b/src/app/ellipsis/ellipsis.directive.spec.ts
@@ -3,7 +3,14 @@ import { Component } from '@angular/core';
 import { EllipsisDirective } from './ellipsis.directive';
 
 // tslint:disable-next-line:max-line-length
-const template = `<p snEllipsis>Ullamco esse laborum dolor eiusmod laboris aliquip aute aute aute. Ullamco velit ad laboris consequat. Deserunt ad reprehenderit cupidatat do labore esse. Occaecat nostrud mollit commodo ut ex elit fugiat et reprehenderit quis. Fugiat aliquip excepteur quis sunt sint consectetur duis elit quis ex fugiat quis eiusmod. Ad pariatur ipsum nulla sunt est non ut id et nisi culpa voluptate mollit ad. Tempor cupidatat esse ad in cillum incididunt quis. Nulla cillum qui aute labore quis ad cillum ullamco adipisicing qui est nulla amet. Nisi consectetur sint nostrud est duis dolore enim aliqua esse laboris Lorem.</p>`;
+const baseContent = `Ullamco esse laborum dolor eiusmod laboris aliquip aute aute aute. Ullamco velit ad laboris consequat. Deserunt ad reprehenderit cupidatat do labore esse. Occaecat nostrud mollit commodo ut ex elit fugiat et reprehenderit quis. Fugiat aliquip excepteur quis sunt sint consectetur duis elit quis ex fugiat quis eiusmod. Ad pariatur ipsum nulla sunt est non ut id et nisi culpa voluptate mollit ad. Tempor cupidatat esse ad in cillum incididunt quis. Nulla cillum qui aute labore quis ad cillum ullamco adipisicing qui est nulla amet. Nisi consectetur sint nostrud est duis dolore enim aliqua esse laboris Lorem.`;
+const trimmedContent = `Ullamco esse laborum dolor eiusmod laboris aliquip aute aute aute. Ullamco velit ad laboris consequat. Deserunt ad reprehenderit cupidatat do labore esse. Occaecat nostrud mollit commodo ut ex elit fugiat et reprehenderit quis. Fugiat aliquip excepteur quis sunt sint consectetur duis elit…`;
+
+const template = `
+  <p class="static" snEllipsis>${baseContent}</p> \
+  <p class="dynamic" snEllipsis>{{ dynamicContent }}</p> \
+  <p class="html" snEllipsis [innerHTML]="htmlContent"></p>
+`;
 
 @Component({
   selector: 'sn-test-component',
@@ -13,10 +20,14 @@ const template = `<p snEllipsis>Ullamco esse laborum dolor eiusmod laboris aliqu
     p { height: 200px; overflow: hidden; padding: 1rem; width: 200px; }
   `]
 })
-class TestComponent { }
+class TestComponent {
+  public dynamicContent: string;
+  public htmlContent: string;
+}
 
-describe('AppComponent', () => {
+describe('EllipsisDirective', () => {
   let fixture: ComponentFixture<TestComponent>;
+  let component: TestComponent;
   let compiled: HTMLElement;
 
   beforeEach(async(() => {
@@ -30,13 +41,30 @@ describe('AppComponent', () => {
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TestComponent);
+    component = fixture.componentInstance;
+
+    component.dynamicContent = baseContent;
+    component.htmlContent = baseContent.split('.').join('. <br><br>');
+
     compiled = fixture.debugElement.nativeElement;
   });
 
-  it('should render directive and clip text', async(() => {
+  it('should clip static text', async(() => {
     fixture.detectChanges();
-    expect(compiled.querySelector('p').textContent)
+    expect(compiled.querySelector('.static').textContent)
+      .toEqual(trimmedContent);
+  }));
+
+  it('should clip dynamic text', async(() => {
+    fixture.detectChanges();
+    expect(compiled.querySelector('.dynamic').textContent)
+      .toEqual(trimmedContent);
+  }));
+
+  it('should clip HTML text', async(() => {
+    fixture.detectChanges();
+    expect(compiled.querySelector('.html').textContent)
       // tslint:disable-next-line:max-line-length
-      .toEqual(`Ullamco esse laborum dolor eiusmod laboris aliquip aute aute aute. Ullamco velit ad laboris consequat. Deserunt ad reprehenderit cupidatat do labore esse. Occaecat nostrud mollit commodo ut ex elit fugiat et reprehenderit quis. Fugiat aliquip excepteur quis sunt sint consectetur duis elit…`);
+      .toEqual(`Ullamco esse laborum dolor eiusmod laboris aliquip aute aute aute. Ullamco velit ad laboris consequat. Deserunt ad reprehenderit cupidatat do labore esse. Occaecat nostrud mollit…`);
   }));
 });

--- a/src/app/ellipsis/ellipsis.directive.ts
+++ b/src/app/ellipsis/ellipsis.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, OnInit } from '@angular/core';
+import { AfterViewInit, Directive, ElementRef } from '@angular/core';
 
 /**
  * Removes excess text from element until it fits in elements
@@ -18,7 +18,7 @@ import { Directive, ElementRef, OnInit } from '@angular/core';
 @Directive({
   selector: '[snEllipsis]'
 })
-export class EllipsisDirective implements OnInit {
+export class EllipsisDirective implements AfterViewInit {
   /**
    * Ellipsis charater
    *
@@ -50,7 +50,7 @@ export class EllipsisDirective implements OnInit {
    *
    * @memberof EllipsisDirective
    */
-  public ngOnInit(): void {
+  public ngAfterViewInit(): void {
     this.clipText();
   }
   /**


### PR DESCRIPTION
Before it was clipping the text OnInit.
In order to support dynamic content, now it uses AfterViewInit

Also add examples for different ways of using it.