### PR TITLE
fix(ellipsis): browser crashing when no lines of text will fit in element

### DIFF
--- a/e2e/app.e2e-spec.ts
+++ b/e2e/app.e2e-spec.ts
@@ -17,7 +17,11 @@ describe('Ellipsis Lib E2E Tests', function () {
   describe('clip text', () => {
     it('should clip text and add ellipsis symbol', () => {
       // tslint:disable-next-line:max-line-length
-      expect(page.getParagraphText()).toEqual(`Ullamco esse laborum dolor eiusmod laboris aliquip aute aute aute. Ullamco velit ad laboris consequat. Deserunt ad reprehenderit cupidatat do labore esse. Occaecat nostrud mollit commodo ut ex elit fugiat et reprehenderit quis. Fugiat aliquip excepteur quis sunt sint consectetur duis elit…`);
+      expect(page.getDefaultParagraphText()).toEqual(`Ullamco esse laborum dolor eiusmod laboris aliquip aute aute aute. Ullamco velit ad laboris consequat. Deserunt ad reprehenderit cupidatat do labore esse. Occaecat nostrud mollit commodo ut ex elit fugiat et reprehenderit quis. Fugiat aliquip excepteur quis sunt sint consectetur duis elit…`);
+    });
+
+    it('should clip text and not loop infinitly', () => {
+      expect(page.getTooSmallParagraphText()).toEqual(`…`);
     });
   });
 

--- a/e2e/app.po.ts
+++ b/e2e/app.po.ts
@@ -5,7 +5,11 @@ export class AppPage {
     return browser.get('/');
   }
 
-  getParagraphText() {
-    return element(by.css('sn-root p')).getText();
+  getDefaultParagraphText() {
+    return element(by.css('sn-root .default')).getText();
+  }
+
+  getTooSmallParagraphText() {
+    return element(by.css('sn-root .too-small')).getText();
   }
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,10 +1,13 @@
 <h1>Examples</h1>
 
 <h2>Static Content</h2>
-<p snEllipsis>Ullamco esse laborum dolor eiusmod laboris aliquip aute aute aute. Ullamco velit ad laboris consequat. Deserunt ad reprehenderit cupidatat do labore esse. Occaecat nostrud mollit commodo ut ex elit fugiat et reprehenderit quis. Fugiat aliquip excepteur quis sunt sint consectetur duis elit quis ex fugiat quis eiusmod. Ad pariatur ipsum nulla sunt est non ut id et nisi culpa voluptate mollit ad. Tempor cupidatat esse ad in cillum incididunt quis. Nulla cillum qui aute labore quis ad cillum ullamco adipisicing qui est nulla amet. Nisi consectetur sint nostrud est duis dolore enim aliqua esse laboris Lorem.</p>
+<p class="default" snEllipsis>Ullamco esse laborum dolor eiusmod laboris aliquip aute aute aute. Ullamco velit ad laboris consequat. Deserunt ad reprehenderit cupidatat do labore esse. Occaecat nostrud mollit commodo ut ex elit fugiat et reprehenderit quis. Fugiat aliquip excepteur quis sunt sint consectetur duis elit quis ex fugiat quis eiusmod. Ad pariatur ipsum nulla sunt est non ut id et nisi culpa voluptate mollit ad. Tempor cupidatat esse ad in cillum incididunt quis. Nulla cillum qui aute labore quis ad cillum ullamco adipisicing qui est nulla amet. Nisi consectetur sint nostrud est duis dolore enim aliqua esse laboris Lorem.</p>
 
 <h2>Content Binding</h2>
 <p snEllipsis>{{ textContent }}</p>
 
 <h2>inneHTML Binding</h2>
 <p snEllipsis [innerHTML]="htmlContent"></p>
+
+<h2>Element too small to fit text</h2>
+<p class="too-small" snEllipsis>Ullamco esse laborum dolor eiusmod laboris aliquip aute aute aute.</p>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -9,3 +9,9 @@ p {
   padding: 1rem;
   width: 200px;
 }
+
+.too-small {
+  font-size: 16px;
+  height: 15px;
+  line-height: 1;
+}

--- a/src/app/ellipsis/ellipsis.directive.spec.ts
+++ b/src/app/ellipsis/ellipsis.directive.spec.ts
@@ -9,7 +9,8 @@ const trimmedContent = `Ullamco esse laborum dolor eiusmod laboris aliquip aute 
 const template = `
   <p class="static" snEllipsis>${baseContent}</p> \
   <p class="dynamic" snEllipsis>{{ dynamicContent }}</p> \
-  <p class="html" snEllipsis [innerHTML]="htmlContent"></p>
+  <p class="html" snEllipsis [innerHTML]="htmlContent"></p> \
+  <p class="too-small" snEllipsis>${baseContent}</p>
 `;
 
 @Component({
@@ -18,6 +19,7 @@ const template = `
   styles: [`
     :host { display: block; font-family: arial, sans-serif; }
     p { height: 200px; overflow: hidden; padding: 1rem; width: 200px; }
+    .too-small { font-size: 16px; height: 15px; line-height: 1; }
   `]
 })
 class TestComponent {
@@ -66,5 +68,11 @@ describe('EllipsisDirective', () => {
     expect(compiled.querySelector('.html').textContent)
       // tslint:disable-next-line:max-line-length
       .toEqual(`Ullamco esse laborum dolor eiusmod laboris aliquip aute aute aute. Ullamco velit ad laboris consequat. Deserunt ad reprehenderit cupidatat do labore esse. Occaecat nostrud mollit…`);
+  }));
+
+  it('should clip text and not loop infinitly', async(() => {
+    fixture.detectChanges();
+    expect(compiled.querySelector('.too-small').textContent)
+      .toEqual(`…`);
   }));
 });

--- a/src/app/ellipsis/ellipsis.directive.ts
+++ b/src/app/ellipsis/ellipsis.directive.ts
@@ -63,7 +63,7 @@ export class EllipsisDirective implements AfterViewInit {
   private clipText(): void {
     const el: HTMLElement = this.el.nativeElement;
     let text = el.innerText.split(' ');
-    while (this.hasOverflow) {
+    while (this.hasOverflow && text.length > 0) {
       text = text.slice(0, -1);
       el.innerText = `${text.join(' ')}${this.ellipsisChar}`;
     }


### PR DESCRIPTION
When the height of the element is less than it's line height so not even a single line of text fits,
the `while` loop in the `clipText` function would never end and would cause the browser to crash. This commit fixes this issue

fixes #10